### PR TITLE
Adds PROJECT_REVISION to cache key.

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -1,6 +1,7 @@
-import { VERSION, addFetchListener } from 'ember-service-worker/service-worker';
+import { PROJECT_REVISION, VERSION, addFetchListener } from 'ember-service-worker/service-worker';
 
-var CACHE_NAME = 'asset-cache-' + VERSION;
+const CACHE_KEY_PREFIX = 'asset-cache-';
+const CACHE_NAME = `${CACHE_KEY_PREFIX}${PROJECT_REVISION}-${VERSION}`;
 
 self.addEventListener('install', function(event) {
   event.waitUntil(
@@ -39,7 +40,7 @@ self.addEventListener('activate', function(event) {
   event.waitUntil(
     caches.keys().then(function(cacheNames) {
       cacheNames.forEach(function(cacheName) {
-        if (cacheName.indexOf('asset-cache-') === 0 && cacheName !== CACHE_NAME) {
+        if (cacheName.indexOf(CACHE_KEY_PREFIX) === 0 && cacheName !== CACHE_NAME) {
           caches.delete(cacheName);
         }
       });


### PR DESCRIPTION
This prevents assets from getting cached across projects (when not using ember-service-worker-project-entangled-registration) and also allows for a straightforward way to add a "kill switch" mechanism for these caches.

We were already using `VERSION` (which was/is pretty good anyways), but I intend to add a "kill switch" mechanism based on `PROJECT_REVISION` (where the consuming project can simply increment a value and ensure that their caches are fully flushed and whatnot).