### PR TITLE
Add missing dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "broccoli-filter": "^1.2.3",
+    "broccoli-plugin": "^1.3.0",
     "ember-cli-babel": "^5.1.6",
     "glob": "^7.1.1"
   },


### PR DESCRIPTION
This plugin, like the other `ember-service-worker-*` plugins, depends on `broccoli-plugin` (in lib/asset-map.js) however this dependency is missing from the package.json.

## Changes proposed in this pull request
Adds `broccoli-plugin` to the dependencies in package.json. Uses same version of `broccoli-plugin` used in other `ember-service-worker-*` plugins.
