### PR TITLE
add "broccoli-merge-trees" to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "broccoli-filter": "^1.2.3",
     "broccoli-plugin": "^1.3.0",
+    "broccoli-merge-trees": "1.1.1",
     "ember-cli-babel": "^5.1.6",
     "glob": "^7.1.1"
   },


### PR DESCRIPTION
"broccoli-merge-trees" is required in `index.js` but not included in the package.json dependencies