### PR TITLE
Allow cross origin requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,20 @@ module.exports = function(defaults) {
 
       // if your files are on a CDN, put the url of your CDN here
       // defaults to `fingerprint.prepend`
-      prepend: 'https://cdn.example.com/'
+      prepend: 'https://cdn.example.com/',
+      
+      // mode of the fetch request. Use 'no-cors' when you are fetching resources
+      // cross origin (different domain) that do not send CORS headers
+      requestMode: 'cors'
     }
   });
 
   return app.toTree();
 };
 ```
+
+*Note that setting `requestMode` to 'no-cors' will have some drawbacks, like not being able to distinguish between
+successful and failed responses. Use it only when needed.*
 
 ## Authors
 

--- a/lib/asset-map.js
+++ b/lib/asset-map.js
@@ -21,6 +21,7 @@ module.exports = class AssetMap extends Plugin {
     let excludes = options.exclude || [];
     let manual = options.manual || [];
     let version = options.version || '1';
+    let requestMode = options.requestMode || 'cors';
 
     let includedFiles = this._findFiles(includes);
     let excludedFiles = this._findFiles(excludes);
@@ -48,7 +49,8 @@ module.exports = class AssetMap extends Plugin {
       module += 'export const PREPEND = undefined;\n';
     }
 
-    module += `export const VERSION = '${version}'`;
+    module += `export const VERSION = '${version}';\n`;
+    module += `export const REQUEST_MODE = '${requestMode}';\n`;
 
     fs.writeFileSync(path.join(this.outputPath, 'config.js'), module);
   }

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -1,7 +1,8 @@
 import {
   FILES,
   PREPEND,
-  VERSION
+  VERSION,
+  REQUEST_MODE
 } from 'ember-service-worker-asset-cache/service-worker/config';
 import cleanupCaches from 'ember-service-worker/service-worker/cleanup-caches';
 
@@ -33,7 +34,7 @@ self.addEventListener('install', (event) => {
       .open(CACHE_NAME)
       .then((cache) => {
         return Promise.all(CACHE_URLS.map((url) => {
-          let request = new Request(url, { mode: 'no-cors' });
+          let request = new Request(url, { mode: REQUEST_MODE });
           return fetch(request)
             .then((response) => {
               if (response.status >= 400) {


### PR DESCRIPTION
I had an issue that assets that were hosted on a CDN (CloudFront/S3 in this case), thus on a different domain, were blocked because the same origin policy also applies to `fetch` calls made in a sw and the CDN did not serve them with CORS headers. The following changes are largely based on this [code sample](https://googlechrome.github.io/samples/service-worker/prefetch/service-worker.js).

## Changes proposed in this pull request

* introduce `requestMode` option to allow 'no-cors' requests
* make seperate fetch requests (cache.addAll seems to not work with so called "opaque" responses (no-cors), rejecting the promise)
* catch initial fetch errors, so sw registration does not fail
* fetch event for non-cached assets (due to previous fetch error) will respond with another network fetch