### PR TITLE
Lenient errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ module.exports = function(defaults) {
 
       // Prevent errors (status of 400 or greater) on a single file
       // from not updating other files that have no issues
-      lenientErrors: true
+      lenientErrors: false
     }
   });
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ module.exports = function(defaults) {
       
       // mode of the fetch request. Use 'no-cors' when you are fetching resources
       // cross origin (different domain) that do not send CORS headers
-      requestMode: 'cors'
+      requestMode: 'cors',
+
+      // Prevent errors (status of 400 or greater) on a single file
+      // from not updating other files that have no issues
+      lenientErrors: true
     }
   });
 

--- a/lib/asset-map.js
+++ b/lib/asset-map.js
@@ -51,6 +51,7 @@ module.exports = class AssetMap extends Plugin {
 
     module += `export const VERSION = '${version}';\n`;
     module += `export const REQUEST_MODE = '${requestMode}';\n`;
+    module += `export const LENIENT_ERRORS = ${options.lenientErrors || false};\n`;
 
     fs.writeFileSync(path.join(this.outputPath, 'config.js'), module);
   }


### PR DESCRIPTION
This adds the `lenientErrors` option, which allows the cache update to continue to other files, skipping the errored file. This feature prevents a stale cache for one file that might not be in the control of the user, like a missing sourcemap in a third-party dependency.