### PR TITLE
Clarify manual setting intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ module.exports = function(defaults) {
         '**/*.gif'
       ],
 
-      // manually include extra assets
+      // manually include extra external assets
       manual: [
         'https://cdn.example.com/foo-library.js'
       ],


### PR DESCRIPTION
I ran into confusion between `include` and `manual` settings.

## Changes proposed in this pull request

Clarify the intent of the `manual` setting.