### PR TITLE
add support to relative url for prepend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ module.exports = function(defaults) {
       // explained here http://ember-service-worker.com/documentation/configuration/#versioning
       version: '1',
 
-      // if your files are on a CDN, put the url of your CDN here
+      // if your files are on a CDN, put the url of your CDN here OR you also can specify relative path from your web site absolute path 
       // defaults to `fingerprint.prepend`
-      prepend: 'https://cdn.example.com/',
+      prepend: 'https://cdn.example.com/', // '/feature/'
       
       // mode of the fetch request. Use 'no-cors' when you are fetching resources
       // cross origin (different domain) that do not send CORS headers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-service-worker-asset-cache",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "An Ember Service Worker plugin that caches an Ember app's asset files",
   "directories": {
     "doc": "doc",

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -9,8 +9,9 @@ import cleanupCaches from 'ember-service-worker/service-worker/cleanup-caches';
 
 const CACHE_KEY_PREFIX = 'esw-asset-cache';
 const CACHE_NAME = `${CACHE_KEY_PREFIX}-${VERSION}`;
+const BASE_URL_FOR_CACHE = PREPEND ?  (/^https?/.test(PREPEND) ? PREPEND : self.location.origin + PREPEND ) : self.location;
 const CACHE_URLS = FILES.map((file) => {
-  return new URL(file, (PREPEND || self.location)).toString();
+  return new URL(file,  BASE_URL_FOR_CACHE).toString();
 });
 
 /*

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -9,7 +9,7 @@ import cleanupCaches from 'ember-service-worker/service-worker/cleanup-caches';
 
 const CACHE_KEY_PREFIX = 'esw-asset-cache';
 const CACHE_NAME = `${CACHE_KEY_PREFIX}-${VERSION}`;
-const BASE_URL_FOR_CACHE = PREPEND ?  (/^https?/.test(PREPEND) ? PREPEND : self.location.origin + PREPEND ) : self.location;
+const BASE_URL_FOR_CACHE = PREPEND ?  (/^[a-z][a-z0-9+.-]*:/.test(PREPEND) ? PREPEND : self.location.origin + PREPEND ) : self.location;
 const CACHE_URLS = FILES.map((file) => {
   return new URL(file,  BASE_URL_FOR_CACHE).toString();
 });


### PR DESCRIPTION
Extend prepend for relative duration
=======================
Currently prepend does not support relative duration so cases caching files other than self.location does not work for relative duration.

e.g.
**https://blah.com/compaykey/feature/sw.js** (service worker is registered from this location)
Our static files are expected to load from below location

**https://blah.com/feature/assets/****
Proposed changes:
Add support for prepend option for relateive duration.

// if your files are on a CDN, put the url of your CDN here OR you also can specify relative path from your web site absolute path
// defaults to `fingerprint.prepend`
prepend: 'https://cdn.example.com/',
OR
prepend: '/feature/', 


