### PR TITLE
Ignore query string for cache match

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -70,11 +70,12 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   let isGETRequest = event.request.method === 'GET';
-  let shouldRespond = CACHE_URLS.indexOf(event.request.url) !== -1;
+  let { origin, pathname } = new URL(event.request.url);
+  let shouldRespond = CACHE_URLS.indexOf(`${origin}${pathname}`) !== -1;
 
   if (isGETRequest && shouldRespond) {
     event.respondWith(
-      caches.match(event.request, { cacheName: CACHE_NAME })
+      caches.match(event.request, { cacheName: CACHE_NAME, ignoreSearch: true })
         .then((response) => {
           if (response) {
             return response;


### PR DESCRIPTION
The query string is also taken into account when looking for a cache match. That means

My app wants to fetch the fontawesome font, from a URL like `fonts/fontawesome-webfont.woff2?v=4.7.0` but it's not going to match the service worker's cache because the add-on expects an exact match on the request URL:

https://github.com/DockYard/ember-service-worker-asset-cache/blob/master/service-worker/index.js#L71-L85

At the same time, caches are stored by their file name, excluding the query string so there will be no match when looking up the cache (as an exact match is required).

![screen shot 2018-10-18 at 17 00 02](https://user-images.githubusercontent.com/5022/47164026-78308180-d2f7-11e8-8f76-6e7336a90087.png)

This PR makes the match less strict by ignoring the query string when matching. I am aware that this might be too loose so I'm happy to make a change to this PR should it be needed.