### PR TITLE
Allow relative urls in prepend

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ module.exports = function(defaults) {
       version: '1',
 
       // if your files are on a CDN, put the url of your CDN here
-      // defaults to `fingerprint.prepend`
+      // can be absolute or relative
+      // overwritten by `fingerprint.prepend`
       prepend: 'https://cdn.example.com/',
-      
+
       // mode of the fetch request. Use 'no-cors' when you are fetching resources
       // cross origin (different domain) that do not send CORS headers
       requestMode: 'cors',

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -9,8 +9,16 @@ import cleanupCaches from 'ember-service-worker/service-worker/cleanup-caches';
 
 const CACHE_KEY_PREFIX = 'esw-asset-cache';
 const CACHE_NAME = `${CACHE_KEY_PREFIX}-${VERSION}`;
+
+// Determine the base url for cache files by testing if the prepend starts with a protocol
+const protocolRegex = /^(?:[a-z0-9]*:)?\/\//i;
+const prependOption = PREPEND  || '';
+const prependIsAbsolute = protocolRegex.test(prependOption);
+const CACHE_BASE_URL = prependIsAbsolute ? prependOption : self.location;
+const CACHE_FILE_PREPEND = prependIsAbsolute || prependOption === '/' ? '' : prependOption;
+
 const CACHE_URLS = FILES.map((file) => {
-  return new URL(file, (PREPEND || self.location)).toString();
+  return new URL(CACHE_FILE_PREPEND + file, CACHE_BASE_URL).toString();
 });
 
 /*


### PR DESCRIPTION
This addresses #41, #35, and #20 by allowing the prepend to be a relative URL. This is required because the fingerprint prepend will override any asset-cache prepend and therefore this plugin needs to be able to handle anything the fingerprint prepend allows.