### PR TITLE
cache response for assets deleted cache

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -87,7 +87,19 @@ self.addEventListener('fetch', (event) => {
           if (response) {
             return response;
           }
-          return fetch(event.request.url, { mode: REQUEST_MODE });
+          return fetch(event.request.url, { mode: REQUEST_MODE }).then(
+            function(response) {
+              if(!response || response.status !== 200 || response.type !== 'basic') {
+                return response;
+              }
+              var responseToCache = response.clone();  
+              caches.open(CACHE_NAME)
+                .then(function(cache) {
+                  cache.put(event.request, responseToCache);
+                });
+              return response;
+            }
+          );
         })
     );
   }


### PR DESCRIPTION
## Changes proposed in this pull request
Whenever the assets get deleted from the cache every subsequent request to that asset results in a network call. To overcome it, we can cache the new response. 
This PR is based on this article [service-workers cache_and_return_requests](https://developers.google.com/web/fundamentals/primers/service-workers#cache_and_return_requests)
